### PR TITLE
tests: cmocka initial support

### DIFF
--- a/kernel/tests/cmocka.c
+++ b/kernel/tests/cmocka.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+ 
+/* A test case that does nothing and succeeds. */
+static void null_test_success(void **state) {
+    (void) state; /* unused */
+}
+ 
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(null_test_success),
+    };
+ 
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/kernel/tests/meson.build
+++ b/kernel/tests/meson.build
@@ -13,8 +13,31 @@ gtest_main = dependency('gmock_main', version: '>=1.13.0',
                          fallback : ['gtest', 'gmock_main_dep'],
                          native: true)
 
-cmocka_proj = subproject('cmocka')
+cmocka_proj = subproject('cmocka',
+                         default_options: 'c_args=-w'
+)
+
 cmocka_dep = cmocka_proj.get_variable('cmocka_native_dep')
+
+# testing cmocka itself, with a generic test case
+test_cmocka = executable(
+    'test_cmocka',
+    sources: [
+        files('cmocka.c')
+    ],
+    override_options: ['c_std=gnu11'],
+    c_args: [
+        global_build_args,
+        '-DTEST_MODE=1',
+    ],
+    dependencies: [ cmocka_dep ],
+    native: true,
+)
+
+test('cmocka-exec',
+     test_cmocka,
+     env: nomalloc,
+     suite: 'cmocka')
 
 subdir('test_utils')
 subdir('test_bsp')

--- a/kernel/tests/meson.build
+++ b/kernel/tests/meson.build
@@ -13,6 +13,9 @@ gtest_main = dependency('gmock_main', version: '>=1.13.0',
                          fallback : ['gtest', 'gmock_main_dep'],
                          native: true)
 
+cmocka_proj = subproject('cmocka')
+cmocka_dep = cmocka_proj.get_variable('cmocka_native_dep')
+
 subdir('test_utils')
 subdir('test_bsp')
 subdir('test_managers')

--- a/kernel/tests/test_bsp/test_exti/meson.build
+++ b/kernel/tests/test_bsp/test_exti/meson.build
@@ -1,6 +1,33 @@
 # SPDX-FileCopyrightText: 2023 Ledger SAS
 # SPDX-License-Identifier: Apache-2.0
 
+
+
+test_bsp_exti_c = executable(
+    'test_bsp_exti_c',
+    sources: [
+        files(
+            'test_exti.c',
+            join_paths(meson.project_source_root(), 'kernel/src/drivers/exti/stm32-exti.c'),
+        ),
+        exti_h, stm32_exti_dtsgen_h, stm32_exti_dtsgen_c,
+        sentry_header_set_config.sources(),
+    ],
+    include_directories: kernel_inc,
+    c_args: [
+        '-I'+join_paths(meson.project_build_root(), 'kernel/src/drivers/exti'),
+        global_build_args,
+        '-DTEST_MODE=1',
+    ],
+    dependencies: [ cmocka_dep, cmsis_dep ],
+    native: true,
+)
+
+test('exti-c',
+     test_bsp_exti_c,
+     env: nomalloc,
+     suite: 'ut-bsp')
+
 test_bsp_exti = executable(
     'test_bsp_exti',
     sources: [

--- a/kernel/tests/test_bsp/test_exti/test_exti.c
+++ b/kernel/tests/test_bsp/test_exti/test_exti.c
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/mman.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <sentry/arch/asm-cortex-m/layout.h>
+#include <bsp/drivers/exti/exti.h>
+#include <sentry/ktypes.h>
+#include "stm32-exti-dt.h"
+
+/* mocked external APIs (out of EXTI module)*/
+kstatus_t mgr_mm_map_kdev(
+        uint32_t addr __attribute__((unused)),
+        size_t size __attribute__((unused))
+    )
+{
+    return K_STATUS_OKAY;
+}
+
+kstatus_t mgr_mm_unmap_kdev(void) {
+    return K_STATUS_OKAY;
+}
+
+/* Setup and teardown */
+typedef struct {
+    void *map;
+} teststate_t;
+
+/* For EXTI we need to allocate an emulated device in a memory area that match the
+ * defined EXTI_BASE_ADDR. This memory area is also set with reset-time values (0x0)
+ * TODO: such a setup should be unified for all bsp test suite, in a local library
+ * to avoid duplication.
+ */
+static int group_setup (void** state) {
+    teststate_t *exti_test = malloc(sizeof(teststate_t));
+    assert(exti_test != NULL);
+
+    exti_test->map = mmap((void*)EXTI_BASE_ADDR, 4096UL, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    if (exti_test->map != (void*)EXTI_BASE_ADDR) {
+        if ((size_t)exti_test->map > EXTI_BASE_ADDR) {
+            printf("Unable to map device to correct address 0x%h\n", EXTI_BASE_ADDR);
+            goto err;
+        }
+        /* the kernel may have align the mapping on 4k size */
+        if ((size_t)exti_test->map + 4096 < (EXTI_BASE_ADDR + 0x400)) {
+            printf("Unable to map device to correct address 0x%h\n", EXTI_BASE_ADDR);
+            printf("Page alignment problem not resolvable\n");
+            printf("address is 0x%h\n\n", exti_test->map);
+            printf(strerror(errno));
+            goto err;
+        }
+        /* page-alignment do include the device*/
+    }
+    if (exti_test->map == (void*)-1) {
+        printf("mmap has failed ! %s\n", strerror(errno));
+        goto err;
+    }
+    /*
+     * push reset values (0x0 for EXTI= in the device. Using standard memory mapping size of device,
+     * portable to any STM32 for offset
+     */
+    for (uint8_t *addr = (uint8_t*)EXTI_BASE_ADDR; addr < (uint8_t*)exti_test->map+0x400; ++addr) {
+        *addr = 0x0;
+    }
+    *state = exti_test;
+    return 0;
+err:
+    return 1;
+}
+
+static int group_teardown(void** state) {
+    teststate_t* exti_test = *state;
+    munmap(exti_test->map, 4096UL);
+    free(exti_test);
+    return 0;
+}
+
+/* A test case that does nothing and succeeds. */
+static void null_test_success(void **state) {
+    (void) state; /* unused */
+}
+ 
+static void test_probe(void **state) {
+    assert_int_equal(exti_probe(), K_STATUS_OKAY);
+}
+ 
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_probe),
+    };
+ 
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}

--- a/subprojects/cmocka.wrap
+++ b/subprojects/cmocka.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = cmocka-1.1.7
+source_url = https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz
+source_filename = cmocka-1.1.7.tar.xz
+source_hash = 810570eb0b8d64804331f82b29ff47c790ce9cd6b163e98d47a4807047ecad82
+patch_filename = cmocka_1.1.7-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/cmocka_1.1.7-3/get_patch
+patch_hash = 527c16d9819a69e69e807eadb4d101cc93b99858120da239da07208562a83d55
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cmocka_1.1.7-3/cmocka-1.1.7.tar.xz
+wrapdb_version = 1.1.7-3
+
+[provide]
+cmocka = cmocka_dep


### PR DESCRIPTION
Adding support for cmocka-based unit testing, as a replacement of gtest.
By now, only a single suite (for EXTI driver), has been added using the cmocka syntax.
