### PR TITLE
UAPI: Add SentryExchangeable trait implementation for ShmHandle.

### DIFF
--- a/uapi/meson.build
+++ b/uapi/meson.build
@@ -82,7 +82,7 @@ test(
         '--',
         '-Dwarnings',
     ],
-    should_fail: true,
+    should_fail: false,
     suite: 'uapi',
 )
 endif # cargo clippy found

--- a/uapi/meson.build
+++ b/uapi/meson.build
@@ -82,7 +82,6 @@ test(
         '--',
         '-Dwarnings',
     ],
-    should_fail: false,
     suite: 'uapi',
 )
 endif # cargo clippy found

--- a/uapi/src/ffi_c.rs
+++ b/uapi/src/ffi_c.rs
@@ -236,9 +236,11 @@ pub extern "C" fn __sys_dma_resume_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_resume_stream(dmah)
 }
 
+/// # Safety
+/// Conditions for code::slice::from_raw_parts are not violated
 /// C interface to [`crate::copy_to_kernel`] Rust implementation
 #[no_mangle]
-pub extern "C" fn copy_to_kernel(from: *mut u8, length: usize) -> Status {
+pub unsafe extern "C" fn copy_to_kernel(from: *mut u8, length: usize) -> Status {
     let u8_slice: &[u8] = unsafe { core::slice::from_raw_parts(from, length) };
     match exchange::copy_to_kernel(&u8_slice) {
         Ok(_) => Status::Ok,
@@ -246,9 +248,11 @@ pub extern "C" fn copy_to_kernel(from: *mut u8, length: usize) -> Status {
     }
 }
 
+/// # Safety
+/// Conditions for code::slice::from_raw_parts are not violated
 /// C interface to [`crate::copy_from_kernel`] Rust implementation
 #[no_mangle]
-pub extern "C" fn copy_from_kernel(to: *mut u8, length: usize) -> Status {
+pub unsafe extern "C" fn copy_from_kernel(to: *mut u8, length: usize) -> Status {
     let mut u8_slice: &mut [u8] =
         unsafe { core::slice::from_raw_parts_mut(to, length) as &mut [u8] };
     match exchange::copy_from_kernel(&mut u8_slice) {

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -7,7 +7,6 @@
 /// Most important enum is `Syscall`, which defines the list of available
 /// syscalls and sets their identifier/number.
 ///
-
 /// This macro takes an enum and implements fallible conversion from a u8
 /// exhaustively, as required by the SVC Handler.
 ///
@@ -621,8 +620,6 @@ mirror_enum! {
 /// a [`Status::Ok`] value.
 /// The kernel return data for a single event type at a time, store in event field,
 /// while wait_for_event() allows waiting for multiple event at a time.
-
-//#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ExchangeHeader {


### PR DESCRIPTION
UAPI: 
 - Add SentryExchangeable trait implementation for ShmHandle
 - Fix clippy warnings & errors
 - TODO: Update documentation on #Safety for unsafe fn()